### PR TITLE
Fix error applying changes with disabled servers

### DIFF
--- a/usr/share/openmediavault/mkconf/nginx.d/90-nginx-server
+++ b/usr/share/openmediavault/mkconf/nginx.d/90-nginx-server
@@ -244,7 +244,7 @@ if [ "$(omv_config_get "${OMV_PLUGIN_XPATH}/enable")" -eq "1" ]; then
 
     while [ $index -lt $server_count -o $index -eq $server_count ]; do
 
-        current_server_xpath="${OMV_NGINX_SERVER_XPATH}[enable = '1' and position()=${index}]"
+        current_server_xpath="${OMV_NGINX_SERVER_XPATH}[enable = '1'][${index}]"
         generate_server_nginx_config "${current_server_xpath}" "${OMV_NGINX_CONF}"
 
         index=$(( ${index} + 1 ))


### PR DESCRIPTION
position() returns an empty node for disabled servers. This causes omv-mkconf to error out when enabled servers follow disabled servers in config.xml