### PR TITLE
Update 90-nginx-server

### DIFF
--- a/usr/share/openmediavault/mkconf/nginx.d/90-nginx-server
+++ b/usr/share/openmediavault/mkconf/nginx.d/90-nginx-server
@@ -163,7 +163,7 @@ generate_server_nginx_config()
     # Add default PHP configuration if it's enabled.
     if [ "$php_enable" -eq 1 ] && [ "$php_use_default_config"  -eq 1 ]; then
         {
-            echo "    location ~ \.php$ {"
+            echo "    location ~ \.php(?:$|/) {"
             echo "        include snippets/fastcgi-php.conf;"
             echo "        fastcgi_pass \$socket;"
             echo "    }"


### PR DESCRIPTION
Fixed 'file not found' errors because of missing php location options, i.e. now "index.php/apps/files/?dir=/&fileid=17" works