### PR TITLE
Update nginx-server.inc

### DIFF
--- a/usr/share/openmediavault/engined/rpc/nginx-server.inc
+++ b/usr/share/openmediavault/engined/rpc/nginx-server.inc
@@ -138,7 +138,7 @@ class NginxServer extends ServiceAbstract
                 $rootFullPath = $this->getSharedFolderPathByUuid($object->get('sharedfolderref'));
 
                 if ($object->get('use_root') && $object->get('use_public_directory')) {
-                    $rootFullPath = build_path([$rootFullPath, $object->get('public_directory')]);
+                    $rootFullPath = build_path(DIRECTORY_SEPARATOR, [$rootFullPath, $object->get('public_directory')]);
                 }
             }
 


### PR DESCRIPTION
Function getList broke with last update of deb/openmediavault/usr/share/php/openmediavault/functions.inc (https://github.com/openmediavault/openmediavault/commit/9c5d10677ecdae1386a748630c30dab1a0d06d42#diff-07cf7334cd6e86338b297c1fb9047a86)
it seems that for years; DIRECTORY_SEPARATOR has been omitted, and the function build_path did not care.