### PR TITLE
Update nginx-server.inc

### DIFF
--- a/usr/share/openmediavault/engined/rpc/nginx-server.inc
+++ b/usr/share/openmediavault/engined/rpc/nginx-server.inc
@@ -138,7 +138,7 @@ class NginxServer extends ServiceAbstract
                 $rootFullPath = $this->getSharedFolderPathByUuid($object->get('sharedfolderref'));
 
                 if ($object->get('use_root') && $object->get('use_public_directory')) {
-                    $rootFullPath = build_path([$rootFullPath, $object->get('public_directory')]);
+                    $rootFullPath = build_path(DIRECTORY_SEPARATOR, $rootFullPath, $object->get('public_directory'));
                 }
             }
 


### PR DESCRIPTION
Line 141 stopped working with the update to build_path (https://github.com/openmediavault/openmediavault/commit/9c5d10677ecdae1386a748630c30dab1a0d06d42#diff-07cf7334cd6e86338b297c1fb9047a86)
See discussion here/
https://forum.openmediavault.org/index.php/Thread/30635-upgrade-error-root-full-path-The-value-is-not-a-string/#post227493